### PR TITLE
SPPSUP-1149: Fix sharenfs issues with locking

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -596,6 +596,20 @@ parseprop(nvlist_t *props, char *propname)
 		    "specified multiple times\n"), propname);
 		return (B_FALSE);
 	}
+
+	/*
+	 * If we are setting the sharenfs property, lock the sharetab to
+	 * ensure concurrent writers don't update the file simultaneously.
+	 * The sharetab will remain locked until the process exits.
+	 */
+	if (strcmp(propname, zfs_prop_to_name(ZFS_PROP_SHARENFS)) == 0) {
+		if (sharetab_lock() != 0) {
+			(void) fprintf(stderr, gettext("unable to set "
+			    "property: %s\n"), strerror(errno));
+			exit(1);
+		}
+	}
+
 	if (nvlist_add_string(props, propname, propval) != 0)
 		nomem();
 	return (B_TRUE);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1142,6 +1142,7 @@ typedef struct ddt_histogram {
 #define	ZFS_DRIVER	"zfs"
 #define	ZFS_DEV		"/dev/zfs"
 #define	ZFS_SHARETAB	"/etc/dfs/sharetab"
+#define	ZFS_SHARETAB_LOCK	"/etc/dfs/sharetab.lck"
 
 #define	ZFS_SUPER_MAGIC	0x2fc12fc1
 

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -173,18 +173,18 @@ sharetab_lock(void)
 {
 	struct flock lock;
 
-	assert(sharetab_fd == -1);
+	verify(sharetab_fd == -1);
 
 	if (mkdir("/etc/dfs", 0755) < 0 && errno != EEXIST) {
 		perror("sharetab_lock: failed to create /etc/dfs");
-		return (-1);
+		return (errno);
 	}
 
 	sharetab_fd = open(ZFS_SHARETAB_LOCK, (O_RDWR | O_CREAT), 0600);
 
 	if (sharetab_fd < 0) {
 		perror("sharetab_lock: failed to open");
-		return (-1);
+		return (errno);
 	}
 
 	lock.l_type = F_WRLCK;
@@ -193,7 +193,7 @@ sharetab_lock(void)
 	lock.l_len = 0;
 	if (fcntl(sharetab_fd, F_SETLKW, &lock) < 0) {
 		perror("sharetab_lock: failed to lock");
-		return (-1);
+		return (errno);
 	}
 	return (0);
 }
@@ -217,7 +217,6 @@ sharetab_unlock(void)
 	return (retval);
 }
 
-
 static void
 update_sharetab(sa_handle_impl_t impl_handle)
 {
@@ -227,7 +226,6 @@ update_sharetab(sa_handle_impl_t impl_handle)
 	char tempfile[] = ZFS_SHARETAB".XXXXXX";
 	sa_fstype_t *fstype;
 	const char *resource;
-
 
 	temp_fd = mkstemp(tempfile);
 

--- a/lib/libspl/include/libshare.h
+++ b/lib/libspl/include/libshare.h
@@ -83,6 +83,9 @@ extern sa_share_t sa_find_share(sa_handle_t, char *);
 extern int sa_enable_share(sa_group_t, char *);
 extern int sa_disable_share(sa_share_t, char *);
 
+extern int sharetab_lock(void);
+extern int sharetab_unlock(void);
+
 /* protocol specific interfaces */
 extern int sa_parse_legacy_options(sa_group_t, char *, char *);
 

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -871,6 +871,7 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL))
 		return (0);
 
+	verify(sharetab_lock() == 0);
 	for (curr_proto = proto; *curr_proto != PROTO_END; curr_proto++) {
 		/*
 		 * Return success if there are no share options.
@@ -886,6 +887,7 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 			(void) zfs_error_fmt(hdl, EZFS_SHARENFSFAILED,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s': %s"),
 			    zfs_get_name(zhp), sa_errorstr(ret));
+			verify(sharetab_unlock() == 0);
 			return (-1);
 		}
 
@@ -917,6 +919,7 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    proto_table[*curr_proto].p_share_err,
 				    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 				    zfs_get_name(zhp));
+				verify(sharetab_unlock() == 0);
 				return (-1);
 			}
 			hdl->libzfs_shareflags |= ZFSSHARE_MISS;
@@ -932,6 +935,7 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    proto_table[*curr_proto].p_share_err,
 				    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 				    zfs_get_name(zhp));
+				verify(sharetab_unlock() == 0);
 				return (-1);
 			}
 		} else {
@@ -939,10 +943,12 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 			    proto_table[*curr_proto].p_share_err,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 			    zfs_get_name(zhp));
+			verify(sharetab_unlock() == 0);
 			return (-1);
 		}
 
 	}
+	verify(sharetab_unlock() == 0);
 	return (0);
 }
 

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -871,7 +871,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL))
 		return (0);
 
-	verify(sharetab_lock() == 0);
 	for (curr_proto = proto; *curr_proto != PROTO_END; curr_proto++) {
 		/*
 		 * Return success if there are no share options.
@@ -887,7 +886,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 			(void) zfs_error_fmt(hdl, EZFS_SHARENFSFAILED,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s': %s"),
 			    zfs_get_name(zhp), sa_errorstr(ret));
-			verify(sharetab_unlock() == 0);
 			return (-1);
 		}
 
@@ -919,7 +917,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    proto_table[*curr_proto].p_share_err,
 				    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 				    zfs_get_name(zhp));
-				verify(sharetab_unlock() == 0);
 				return (-1);
 			}
 			hdl->libzfs_shareflags |= ZFSSHARE_MISS;
@@ -935,7 +932,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    proto_table[*curr_proto].p_share_err,
 				    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 				    zfs_get_name(zhp));
-				verify(sharetab_unlock() == 0);
 				return (-1);
 			}
 		} else {
@@ -943,12 +939,10 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 			    proto_table[*curr_proto].p_share_err,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 			    zfs_get_name(zhp));
-			verify(sharetab_unlock() == 0);
 			return (-1);
 		}
 
 	}
-	verify(sharetab_unlock() == 0);
 	return (0);
 }
 

--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -272,6 +272,7 @@ maybe = {
     'snapshot/clone_001_pos': ['FAIL', known_reason],
     'snapshot/snapshot_009_pos': ['FAIL', '7961'],
     'snapshot/snapshot_010_pos': ['FAIL', '7961'],
+    'snapshot/rollback_003_pos': ['FAIL', '6143'],
     'snapused/snapused_004_pos': ['FAIL', '5513'],
     'tmpfile/setup': ['SKIP', tmpfile_reason],
     'threadsappend/threadsappend_001_pos': ['FAIL', '6136'],


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
