### PR TITLE
Evict refcount=1 entries when DDT large

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -213,6 +213,7 @@ extern boolean_t ddt_histogram_empty(const ddt_histogram_t *ddh);
 extern void ddt_get_dedup_object_stats(spa_t *spa, ddt_object_t *ddo);
 extern void ddt_get_dedup_histogram(spa_t *spa, ddt_histogram_t *ddh);
 extern void ddt_get_dedup_stats(spa_t *spa, ddt_stat_t *dds_total);
+extern void ddt_stat_update(ddt_t *ddt, ddt_entry_t *dde, uint64_t neg);
 
 extern uint64_t ddt_get_dedup_dspace(spa_t *spa);
 extern uint64_t ddt_get_pool_dedup_ratio(spa_t *spa);

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -2613,6 +2613,19 @@ Default value: \fB5\fR.
 .sp
 .ne 2
 .na
+\fBzfs_unique_ddt_max\fR (ulong)
+.ad
+.RS 12n
+Max unique refcount=1 entries in bytes. Default value is 128MB.
+.sp
+This value can be changed dynamically.
+.sp
+Default value: \fB134217728\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_vdev_aggregate_trim\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -514,7 +514,8 @@ dbuf_verify_user(dmu_buf_impl_t *db, dbvu_verify_type_t verify_type)
 
 	/* Clients must resolve a dbuf before attaching user data. */
 	ASSERT(db->db.db_data != NULL);
-	ASSERT3U(db->db_state, ==, DB_CACHED);
+	if (db->db_blkid != DMU_BONUS_BLKID)
+		ASSERT3U(db->db_state, ==, DB_CACHED);
 
 	holds = zfs_refcount_count(&db->db_holds);
 	if (verify_type == DBVU_EVICTING) {

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3352,16 +3352,72 @@ zio_ddt_free(zio_t *zio)
 	ddt_t *ddt = ddt_select(spa, bp);
 	ddt_entry_t *dde;
 	ddt_phys_t *ddp;
+	boolean_t added = B_FALSE;
 
 	ASSERT(BP_GET_DEDUP(bp));
 	ASSERT(zio->io_child_type == ZIO_CHILD_LOGICAL);
 
 	ddt_enter(ddt);
-	freedde = dde = ddt_lookup(ddt, bp, B_TRUE);
-	if (dde) {
-		ddp = ddt_phys_select(dde, bp);
-		if (ddp)
-			ddt_phys_decref(ddp);
+	dde = ddt_lookup(ddt, bp, B_FALSE);
+	if (dde == NULL) {
+		dde = ddt_lookup(ddt, bp, B_TRUE);
+		added = B_TRUE;
+	}
+	freedde = dde;
+	ddp = ddt_phys_select(dde, bp);
+	if (ddp != NULL) {
+#if defined(ZFS_DEBUG) && !defined(_KERNEL)
+		(void) printf("zio_ddt_free(vd=%llu off=%llx) found matching entry with rc=%llu\n",
+		    (long long)DVA_GET_VDEV(BP_IDENTITY(bp)),
+		    (long long)DVA_GET_OFFSET(BP_IDENTITY(bp)),
+		    (long long)ddt_phys_total_refcnt(dde));
+		ddt_phys_decref(ddp);
+#endif
+	} else {
+#if defined(ZFS_DEBUG) && !defined(_KERNEL)
+		 (void) printf("zio_ddt_free(vd=%llu off=%llx) non-matching, added=%u rc=%llu\n",
+		    (long long)DVA_GET_VDEV(BP_IDENTITY(bp)),
+		    (long long)DVA_GET_OFFSET(BP_IDENTITY(bp)),
+		    added,
+		    (long long)ddt_phys_total_refcnt(dde));
+#endif
+		/*
+  		 * ddt_phys_select() failed, because this entry was evicted
+  		 * from the DDT (see ddt_sync_table()).  It can fail in two
+  		 * cases: the dde is "fresh" (there's no corresponding
+  		 * on-disk entry, and the dde's refcount is zero); or the
+  		 * dde's phys birth time doesn't match the bp's (after our
+  		 * entry was evicted, a block with the same checksum was
+  		 * re-added to the DDT). In this case, we know the
+  		 * effective refcount is currently 1 (because we only evict
+  		 * from DDT_CLASS_UNIQUE), so it is being effectively
+  		 * decremented to 0 and we need to free this block.
+  		 */
+		zio->io_pipeline = ZIO_FREE_PIPELINE;
+		if (zio->io_child_type > ZIO_CHILD_GANG && BP_IS_GANG(bp))
+			zio->io_pipeline |= ZIO_GANG_STAGES;
+		if (added) {
+			/*
+  			 * Our call to ddt_lookup() added the in-memory
+  			 * dde.  We need to undo this, because we are not
+  			 * actually modifying the on-disk DDT.  This is
+  			 * true whether the in-memory dde is "fresh", or it
+  			 * corresponds to an on-disk entry in the DDT
+  			 * (caused by the evict and re-add case).
+  			 */
+			if (ddt_phys_total_refcnt(dde) > 0)
+				ddt_stat_update(ddt, dde, 0);
+			/* If another thread called ddt_lookup()
+  			 * on a bp with the same checksum, they could be
+  			 * referencing this dde (in ddt_lookup(), waiting
+  			 * for us to drop the ddt_lock).  When we
+  			 * free the dde, they will dereference freed
+  			 * memory. We can call ddt_remove(ddt,dde), but we
+  			 * risk racing. If we do not call it, then the dde
+  			 * will live until the end of the txg, which is
+  			 * minimal risk.
+  			 */
+		}
 	}
 	ddt_exit(ddt);
 


### PR DESCRIPTION
This patch builds upon Matt Ahrens' initial
hackathon patch from:

https://www.youtube.com/watch?v=PYxFDBgxFS8

Signed-off-by: Bryant G. Ly <bly@catalogicsoftware.com>