### PR TITLE
ddt_refcount: Fix ddt entry deletion

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3371,11 +3371,11 @@ zio_ddt_free(zio_t *zio)
 		    (long long)DVA_GET_VDEV(BP_IDENTITY(bp)),
 		    (long long)DVA_GET_OFFSET(BP_IDENTITY(bp)),
 		    (long long)ddt_phys_total_refcnt(dde));
-		ddt_phys_decref(ddp);
 #endif
+		ddt_phys_decref(ddp);
 	} else {
 #if defined(ZFS_DEBUG) && !defined(_KERNEL)
-		 (void) printf("zio_ddt_free(vd=%llu off=%llx) non-matching, added=%u rc=%llu\n",
+		(void) printf("zio_ddt_free(vd=%llu off=%llx) non-matching, added=%u rc=%llu\n",
 		    (long long)DVA_GET_VDEV(BP_IDENTITY(bp)),
 		    (long long)DVA_GET_OFFSET(BP_IDENTITY(bp)),
 		    added,


### PR DESCRIPTION
DDT entries were not getting deleted when fs destroyed

Signed-off-by: Bryant G. Ly <bly@catalogicsoftware.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
