### PR TITLE
DLPX-62600 zfs sharenfs commands make slow progress on scalability sy…

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1648,12 +1648,9 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 {
 	export_cbdata_t *cb = data;
 
-	verify(sharetab_lock() == 0);
 	if (zpool_disable_datasets(zhp, cb->force || cb->hardforce) != 0) {
-		verify(sharetab_unlock() == 0);
 		return (1);
 	}
-	verify(sharetab_unlock() == 0);
 
 	/* The history must be logged as part of the export */
 	log_history = B_FALSE;
@@ -1727,7 +1724,9 @@ zpool_do_export(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
+	verify(sharetab_lock() == 0);
 	ret = for_each_pool(argc, argv, B_TRUE, NULL, zpool_export_one, &cb);
+	verify(sharetab_unlock() == 0);
 
 	return (ret);
 }

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -92,6 +92,20 @@ sa_init(int init_service)
 
 	impl_handle->zfs_libhandle = libzfs_init();
 
+	/*
+	 * When libshare initializes the shares below, it needs to parse the
+	 * MNTTAB to determine if a filesystem is mounted by calling
+	 * zfs_is_mounted(). On systems with thousands of filesystems,
+	 * repeatedly parsing the MNTTAB can be very slow. As a performance
+	 * improvement, we cache the MNTTAB so that we only have to read it
+	 * once. Repeated calls to zfs_is_mounted will just lookup entries in
+	 * the AVL tree. We can only safely do this when we've locked the
+	 * sharetab to other zfs sharenfs operations from concurrently
+	 * updating the MNTTAB.
+	 */
+	if (sharetab_locked())
+		libzfs_mnttab_cache(impl_handle->zfs_libhandle, B_TRUE);
+
 	if (impl_handle->zfs_libhandle != NULL) {
 		libzfs_print_on_error(impl_handle->zfs_libhandle, B_TRUE);
 	}
@@ -216,6 +230,12 @@ sharetab_unlock(void)
 	close(sharetab_fd);
 	sharetab_fd = -1;
 	return (retval);
+}
+
+boolean_t
+sharetab_locked(void)
+{
+	return(sharetab_fd != -1);
 }
 
 static void

--- a/lib/libspl/include/libshare.h
+++ b/lib/libspl/include/libshare.h
@@ -87,6 +87,7 @@ extern int sa_generate_share(const char *, const char *);
 
 extern int sharetab_lock(void);
 extern int sharetab_unlock(void);
+extern boolean_t sharetab_locked(void);
 
 /* protocol specific interfaces */
 extern int sa_parse_legacy_options(sa_group_t, char *, char *);


### PR DESCRIPTION
…stem (#45)

Signed-off-by: Bryant G. Ly <bly@catalogicsoftware.com>

Conflicts:
	cmd/zpool/zpool_main.c

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
