### PR TITLE
ddt_unique_max

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -2860,11 +2860,13 @@ Default value: \fB5\fR.
 \fBzfs_unique_ddt_max\fR (ulong)
 .ad
 .RS 12n
-Max unique refcount=1 entries in bytes. Default value is 128MB.
+Max unique refcount=1 entries in bytes. Default value is 0, which is off.
+The value needs to be 1024 bytes or higher, otherwise value will get
+rejected and defaulted back to off. 
 .sp
 This value can be changed dynamically.
 .sp
-Default value: \fB134217728\fR.
+Default value: \fB0\fR.
 .RE
 
 .sp

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -51,7 +51,7 @@ int zfs_dedup_prefetch = 0;
  * If more entries are added, old (randomly selected) entries will be evicted.
  * Assuming each entry is 320bytes, 128MB/320 = 134217728/320 = 419430 entries
  */
-#define	DDT_UNIQUE_MAX_SIZE		134217728
+#define	DDT_UNIQUE_MAX_SIZE		0
 unsigned long zfs_unique_ddt_max = DDT_UNIQUE_MAX_SIZE;
 
 static const ddt_ops_t *ddt_ops[DDT_TYPES] = {
@@ -1210,9 +1210,9 @@ ddt_unique_max_size(void)
   	 * altered them.
   	 */
 	size = zfs_unique_ddt_max;
-	if (size == 0) {
+	if (size < 1024) {
 		cmn_err(CE_NOTE, "Bad value for zfs_unique_ddt_max, value must "
-		    "be greater than zero, resetting it to the default (%d)",
+		    "be greater than 1024 bytes, resetting it to the default (%d)",
 		    DDT_UNIQUE_MAX_SIZE);
 		size = zfs_unique_ddt_max = DDT_UNIQUE_MAX_SIZE;
 	}
@@ -1265,7 +1265,7 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx, uint64_t txg)
   	 * unique entries they want for their own data, depending on what kind
   	 * of writes they are doing.
   	 */
-	if (ddt_object_exists(ddt, DDT_TYPE_CURRENT, DDT_CLASS_UNIQUE)) {
+	if (ddt_object_exists(ddt, DDT_TYPE_CURRENT, DDT_CLASS_UNIQUE) && (ddt_unique_max != 0)) {
 		uint64_t count = 0;
 		VERIFY(ddt_object_count(ddt, DDT_TYPE_CURRENT, DDT_CLASS_UNIQUE, &count) == 0);
 		for (int64_t i = 0; i < (int64_t)(count - ddt_unique_max); i++) {


### PR DESCRIPTION
Setting the default refcount eviction =1 to be off.
The value needs to be above 1024bytes otherwise,
the value will default to off which is 0.

Signed-off-by: Bryant G. Ly <bly@catalogicsoftware.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
