### PR TITLE
Buildfix: the const-ification of the holder parameter was mismerged

### DIFF
--- a/include/sys/refcount.h
+++ b/include/sys/refcount.h
@@ -72,15 +72,16 @@ void zfs_refcount_destroy(zfs_refcount_t *);
 void zfs_refcount_destroy_many(zfs_refcount_t *, uint64_t);
 int zfs_refcount_is_zero(zfs_refcount_t *);
 int64_t zfs_refcount_count(zfs_refcount_t *);
-int64_t _zfs_refcount_add(zfs_refcount_t *, void *, const char *, size_t);
+int64_t _zfs_refcount_add(zfs_refcount_t *, const void *, const char *,
+    size_t);
 #define	zfs_refcount_add(rc, holder_tag)	\
 	_zfs_refcount_add(rc, holder_tag, __FILE__, __LINE__)
-int64_t zfs_refcount_remove(zfs_refcount_t *, void *);
-int64_t _zfs_refcount_add_many(zfs_refcount_t *, uint64_t, void *, const char *,
-    size_t);
+int64_t zfs_refcount_remove(zfs_refcount_t *, const void *);
+int64_t _zfs_refcount_add_many(zfs_refcount_t *, uint64_t, const void *,
+    const char *, size_t);
 #define	zfs_refcount_add_many(rc, number, holder_tag)	\
 	_zfs_refcount_add_many(rc, number, holder_tag, __FILE__, __LINE__)
-int64_t zfs_refcount_remove_many(zfs_refcount_t *, uint64_t, void *);
+int64_t zfs_refcount_remove_many(zfs_refcount_t *, uint64_t, const void *);
 void zfs_refcount_transfer(zfs_refcount_t *, zfs_refcount_t *);
 void zfs_refcount_transfer_ownership(zfs_refcount_t *, const void *,
     const void *);

--- a/module/zfs/refcount.c
+++ b/module/zfs/refcount.c
@@ -121,7 +121,7 @@ zfs_refcount_count(zfs_refcount_t *rc)
 }
 
 int64_t
-_zfs_refcount_add_many(zfs_refcount_t *rc, uint64_t number, void *holder,
+_zfs_refcount_add_many(zfs_refcount_t *rc, uint64_t number, const void *holder,
     const char *file, size_t line)
 {
 	reference_t *ref = NULL;
@@ -146,7 +146,7 @@ _zfs_refcount_add_many(zfs_refcount_t *rc, uint64_t number, void *holder,
 }
 
 int64_t
-_zfs_refcount_add(zfs_refcount_t *rc, void *holder, const char *file,
+_zfs_refcount_add(zfs_refcount_t *rc, const void *holder, const char *file,
     size_t line)
 {
 	return (_zfs_refcount_add_many(rc, 1, holder, file, line));


### PR DESCRIPTION
When 0.8.3 was merged in, the local changes to zfs_refcount_* to track the file/line where the refcount came from, were mismerged (the addition of the `const` keyword to the `void *holder` was missed)

The branch does not build for me without this fix.

Signed-off-by: Allan Jude <allanjude@freebsd.org>