### PR TITLE
SPPSUP-1354: Fix panic on dmu.c

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1134,9 +1134,9 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 
 	error = dmu_buf_hold_array(os, object, offset, size,
 	    FALSE, FTAG, &numbufs, &dbp);
-	VERIFY(error == 0 || spa_exiting_any(os->os_spa));
-	if (error != 0)
+	if (error != 0 && spa_exiting_any(os->os_spa) != 0)
 		return;
+	VERIFY3U(error, ==, 0);
 	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
@@ -1328,9 +1328,9 @@ dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
 	ASSERT3U(comp, <, ZIO_COMPRESS_FUNCTIONS);
 	error = dmu_buf_hold_noread(os, object, offset,
 	    FTAG, &db);
-	VERIFY(error == 0 || spa_exiting_any(os->os_spa));
-	if (error != 0)
+	if (error != 0 && spa_exiting_any(os->os_spa) != 0)
 		return;
+	VERIFY3U(error, ==, 0);
 
 	dmu_buf_write_embedded(db,
 	    data, (bp_embedded_type_t)etype, (enum zio_compress)comp,


### PR DESCRIPTION
Mar  8 11:38:15 d40p010b kernel: VERIFY(error == 0 ||
spa_exiting_any(os->os_spa)) failed
Mar  8 11:38:15 d40p010b kernel: PANIC at dmu.c:1137:dmu_write()
Mar  8 11:38:15 d40p010b kernel: Showing stack for process 24602
Mar  8 11:38:15 d40p010b kernel: CPU: 3 PID: 24602 Comm: txg_sync Kdump:
loaded Tainted: P           OE     4.19.101-1c.el7.x86_64 #1
Mar  8 11:38:15 d40p010b kernel: Hardware name: VMware, Inc. VMware
Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 12/12/2018
Mar  8 11:38:15 d40p010b kernel: Call Trace:
Mar  8 11:38:15 d40p010b kernel: dump_stack+0x64/0x83
Mar  8 11:38:15 d40p010b kernel: spl_panic+0xc9/0x110 [spl]
Mar  8 11:38:15 d40p010b kernel: ? zio_nowait+0xa0/0x120 [zfs]
Mar  8 11:38:15 d40p010b kernel: ?
dmu_buf_hold_array_by_dnode+0x35c/0x4a0 [zfs]
Mar  8 11:38:15 d40p010b kernel: ? __raw_spin_unlock+0x5/0x10 [zfs]
Mar  8 11:38:15 d40p010b kernel: ? dnode_rele_and_unlock+0x5b/0xb0 [zfs]
Mar  8 11:38:15 d40p010b kernel: ?
dmu_buf_hold_array.constprop.7+0x7e/0xb0 [zfs]
Mar  8 11:38:15 d40p010b kernel: ? spl_kmem_cache_free+0xd0/0x130 [spl]
Mar  8 11:38:15 d40p010b kernel: dmu_write+0xde/0xf0 [zfs]
Mar  8 11:38:15 d40p010b kernel: ? mutex_lock+0xe/0x30
Mar  8 11:38:15 d40p010b kernel: space_map_write_intro_debug+0xaf/0xe0
[zfs]
Mar  8 11:38:15 d40p010b kernel: space_map_write_impl+0x4d/0x240 [zfs]
Mar  8 11:38:15 d40p010b kernel: ? _cond_resched+0x15/0x30
Mar  8 11:38:15 d40p010b kernel: ? mutex_lock+0xe/0x30
Mar  8 11:38:15 d40p010b kernel: space_map_write+0xe9/0x1a0 [zfs]
Mar  8 11:38:15 d40p010b kernel: metaslab_flush+0x1ce/0x360 [zfs]
Mar  8 11:38:15 d40p010b kernel: ?
spa_generate_syncing_log_sm+0x14f/0x240 [zfs]
Mar  8 11:38:15 d40p010b kernel: spa_flush_metaslabs+0x169/0x1f0 [zfs]
Mar  8 11:38:15 d40p010b kernel:
spa_sync_iterate_to_convergence+0x140/0x1e0 [zfs]
Mar  8 11:38:15 d40p010b kernel: spa_sync+0x355/0x610 [zfs]
Mar  8 11:38:15 d40p010b kernel: txg_sync_thread+0x26c/0x310 [zfs]
Mar  8 11:38:15 d40p010b kernel: ? txg_completion_notify+0x90/0x90 [zfs]
Mar  8 11:38:15 d40p010b kernel: thread_generic_wrapper+0x6f/0x80 [spl]
Mar  8 11:38:15 d40p010b kernel: kthread+0xf8/0x130
Mar  8 11:38:15 d40p010b kernel: ? __thread_exit+0x20/0x20 [spl]
Mar  8 11:38:15 d40p010b kernel: ? kthread_bind+0x10/0x10
Mar  8 11:38:15 d40p010b kernel: ret_from_fork+0x35/0x40
Mar  8 11:38:15 d40p010b tcmu-runner: 2020/03/08 11:38:15 INFO: Close
fd: 2601737962671218114

Signed-off-by: Bryant G. Ly <bly@catalogicsoftware.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
