### PR TITLE
SPP-11912: Don't show zpool/zfs usage if run via wrapper command

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -480,6 +480,13 @@ usage(boolean_t requested)
 	boolean_t show_properties = B_FALSE;
 	FILE *fp = requested ? stdout : stderr;
 
+	/*
+	 * Don't show usage if run via wrapper command
+	 */
+	if (getenv("VSCMD_WRAPPER") != NULL) {
+		exit(requested ? 0 : 2);
+	}
+
 	if (current_command == NULL) {
 
 		(void) fprintf(fp, gettext("usage: zfs command args ...\n"));

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -484,6 +484,13 @@ usage(boolean_t requested)
 {
 	FILE *fp = requested ? stdout : stderr;
 
+	/*
+	 * Don't show usage if run via wrapper command
+	 */
+	if (getenv("VSCMD_WRAPPER") != NULL) {
+		exit(requested ? 0 : 2);
+	}
+
 	if (current_command == NULL) {
 		int i;
 


### PR DESCRIPTION
Signed-off-by: Siddharth Bhatt <sbhatt@catalogicsoftware.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `zpool` or `zfs` commands are invoked via a vSnap wrapper command, we do not want to show usage help on screen.

### Description
<!--- Describe your changes in detail -->
The wrapper commands set an environment variable named `VSCMD_WRAPPER`. This change looks for that variable and skips showing usage help if it is set.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Unit tested on a dev appliance by invoking the commands with and without the environment variable being set.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
