### PR TITLE
Skip flushing metaslabs during a forced export

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2307,7 +2307,7 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p. continue", db);
-	} else if (db->db.db_buf == NULL) {
+	} else if (db->db_buf == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL db_buf! db=%p. continue", db);
 	}
 
@@ -2388,7 +2388,7 @@ dmu_buf_will_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf! db=%p", db);
-	} else if (db->db.db_buf == NULL) {
+	} else if (db->db_buf == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL db_buf! db=%p", db);
 	}
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2064,6 +2064,10 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 					cmn_err(CE_WARN, "dbuf_dirty(): NULL dbuf! db=%p", db);
 				} else if(db->db_buf == NULL) {
 					cmn_err(CE_WARN, "dbuf_dirty(): NULL dbuf buf! db=%p db_buf=%p", db, db->db_buf);
+					if (spa_exiting_any(os->os_spa)) {
+						cmn_err(CE_WARN, "dbuf_dirty(): forced export + NULL, aborting");
+						return;
+					}
 				} else {
 					arc_release(db->db_buf, db);
 					dbuf_fix_old_data(db, tx->tx_txg);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2305,12 +2305,6 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 
-	if (db == NULL) {
-		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p. continue", db);
-	} else if (db->db_buf == NULL) {
-		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL db_buf! db=%p. continue", db);
-	}
-
 	ASSERT(tx->tx_txg != 0);
 	ASSERT(!zfs_refcount_is_zero(&db->db_holds));
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2066,7 +2066,7 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 					cmn_err(CE_WARN, "dbuf_dirty(): NULL dbuf buf! db=%p db_buf=%p", db, db->db_buf);
 					if (spa_exiting_any(os->os_spa)) {
 						cmn_err(CE_WARN, "dbuf_dirty(): forced export + NULL, aborting");
-						return;
+						return (NULL);
 					}
 				} else {
 					arc_release(db->db_buf, db);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2060,7 +2060,13 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 				 * syncing state (since they are only modified
 				 * then).
 				 */
-				arc_release(db->db_buf, db);
+				if (db == NULL) {
+					cmn_err(CE_WARN, "NULL dbuf! db=%p", db);
+				} else if(db->db_buf == NULL) {
+					cmn_err(CE_WARN, "NULL dbuf buf! db=%p db_buf=%p", db, db->db_buf);
+				} else {
+					arc_release(db->db_buf, db);
+				}
 				dbuf_fix_old_data(db, tx->tx_txg);
 				data_old = db->db_buf;
 			}

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2308,7 +2308,7 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p", db);
 		return;
-	} else if (db->db_data == NULL) {
+	} else if (db->db.db_data == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf_data! db=%p", db);
 		return;
 	}
@@ -2391,7 +2391,7 @@ dmu_buf_will_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf! db=%p", db);
 		return;
-	} else if (db->db_data == NULL) {
+	} else if (db->db.db_data == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf_data! db=%p", db);
 		return;
 	}

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2061,9 +2061,9 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 				 * then).
 				 */
 				if (db == NULL) {
-					cmn_err(CE_WARN, "NULL dbuf! db=%p", db);
+					cmn_err(CE_WARN, "dbuf_dirty(): NULL dbuf! db=%p", db);
 				} else if(db->db_buf == NULL) {
-					cmn_err(CE_WARN, "NULL dbuf buf! db=%p db_buf=%p", db, db->db_buf);
+					cmn_err(CE_WARN, "dbuf_dirty(): NULL dbuf buf! db=%p db_buf=%p", db, db->db_buf);
 				} else {
 					arc_release(db->db_buf, db);
 					dbuf_fix_old_data(db, tx->tx_txg);
@@ -2307,8 +2307,8 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p. continue", db);
-	} else if (db->db.db_data == NULL) {
-		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf_data! db=%p. continue", db);
+	} else if (db->db.db_buf == NULL) {
+		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL db_buf! db=%p. continue", db);
 	}
 
 	ASSERT(tx->tx_txg != 0);
@@ -2388,8 +2388,8 @@ dmu_buf_will_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf! db=%p", db);
-	} else if (db->db.db_data == NULL) {
-		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf_data! db=%p", db);
+	} else if (db->db.db_buf == NULL) {
+		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL db_buf! db=%p", db);
 	}
 
 	ASSERT(db->db_blkid != DMU_BONUS_BLKID);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2066,8 +2066,8 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 					cmn_err(CE_WARN, "NULL dbuf buf! db=%p db_buf=%p", db, db->db_buf);
 				} else {
 					arc_release(db->db_buf, db);
+					dbuf_fix_old_data(db, tx->tx_txg);
 				}
-				dbuf_fix_old_data(db, tx->tx_txg);
 				data_old = db->db_buf;
 			}
 			ASSERT(data_old != NULL);
@@ -2308,6 +2308,9 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p", db);
 		return;
+	} else if (db->db_data == NULL) {
+		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf_data! db=%p", db);
+		return;
 	}
 
 	ASSERT(tx->tx_txg != 0);
@@ -2387,6 +2390,9 @@ dmu_buf_will_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf! db=%p", db);
+		return;
+	} else if (db->db_data == NULL) {
+		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf_data! db=%p", db);
 		return;
 	}
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2385,6 +2385,11 @@ dmu_buf_will_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 
+	if (db == NULL) {
+		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf! db=%p", db);
+		return;
+	}
+
 	ASSERT(db->db_blkid != DMU_BONUS_BLKID);
 	ASSERT(tx->tx_txg != 0);
 	ASSERT(db->db_level == 0);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2306,9 +2306,9 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 
 	if (db == NULL) {
-		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p", db);
+		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p. continue", db);
 	} else if (db->db.db_data == NULL) {
-		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf_data! db=%p", db);
+		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf_data! db=%p. continue", db);
 	}
 
 	ASSERT(tx->tx_txg != 0);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2307,10 +2307,8 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p", db);
-		return;
 	} else if (db->db.db_data == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf_data! db=%p", db);
-		return;
 	}
 
 	ASSERT(tx->tx_txg != 0);
@@ -2390,10 +2388,8 @@ dmu_buf_will_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 
 	if (db == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf! db=%p", db);
-		return;
 	} else if (db->db.db_data == NULL) {
 		cmn_err(CE_WARN, "dmu_buf_will_fill() NULL dbuf_data! db=%p", db);
-		return;
 	}
 
 	ASSERT(db->db_blkid != DMU_BONUS_BLKID);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2305,6 +2305,11 @@ dmu_buf_will_dirty_impl(dmu_buf_t *db_fake, int flags, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 
+	if (db == NULL) {
+		cmn_err(CE_WARN, "dmu_buf_will_dirty_impl() NULL dbuf! db=%p", db);
+		return;
+	}
+
 	ASSERT(tx->tx_txg != 0);
 	ASSERT(!zfs_refcount_is_zero(&db->db_holds));
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1129,6 +1129,9 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	int numbufs;
 	int error;
 
+	if (spa_exiting_any(os->os_spa))
+		return;
+
 	if (size == 0)
 		return;
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1105,11 +1105,9 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 		dmu_buf_t *db = dbp[i];
 
 		if (db == NULL) {
-			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf! db=%p", db);
-			return;
+			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf! db=%p. Continuing anyway", db);
 		} else if (db->db_data == NULL) {
-			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf_data! db=%p db->db_data=%p", db, db->db_data);
-			return;
+			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf_data! db=%p db->db_data=%p. Continuing anyway", db, db->db_data);
 		}
 
 		ASSERT(size > 0);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1120,8 +1120,6 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf! db=%p. Continuing anyway", db);
 		} else if (db->db_data == NULL) {
 			cmn_err(CE_WARN, "dmu_write_impl() NULL db_data! db=%p db->db_data=%p. Continuing anyway", db, db->db_data);
-		} else if (db->db_buf == NULL) {
-			cmn_err(CE_WARN, "dmu_write_impl() NULL db_buf! db=%p db->db_buf=%p. Continuing anyway", db, db->db_buf);
 		}
 
 		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1104,12 +1104,6 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 		int64_t bufoff;
 		dmu_buf_t *db = dbp[i];
 
-		if (db == NULL) {
-			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf! db=%p. Continuing anyway", db);
-		} else if (db->db_data == NULL) {
-			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf_data! db=%p db->db_data=%p. Continuing anyway", db, db->db_data);
-		}
-
 		ASSERT(size > 0);
 
 		bufoff = offset - db->db_offset;
@@ -1121,6 +1115,14 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 			dmu_buf_will_fill(db, tx);
 		else
 			dmu_buf_will_dirty(db, tx);
+
+		if (db == NULL) {
+			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf! db=%p. Continuing anyway", db);
+		} else if (db->db_data == NULL) {
+			cmn_err(CE_WARN, "dmu_write_impl() NULL db_data! db=%p db->db_data=%p. Continuing anyway", db, db->db_data);
+		} else if (db->db_buf == NULL) {
+			cmn_err(CE_WARN, "dmu_write_impl() NULL db_buf! db=%p db->db_buf=%p. Continuing anyway", db, db->db_buf);
+		}
 
 		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1119,10 +1119,10 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 		if (db == NULL) {
 			cmn_err(CE_WARN, "dmu_write_impl() NULL dbuf! db=%p. Continuing anyway", db);
 		} else if (db->db_data == NULL) {
-			cmn_err(CE_WARN, "dmu_write_impl() NULL db_data! db=%p db->db_data=%p. Continuing anyway", db, db->db_data);
+			cmn_err(CE_WARN, "dmu_write_impl() NULL db_data! db=%p db->db_data=%p db->db_size=%lu. Skipping memcpy", db, db->db_data, db->db_size);
+		} else {
+			(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
 		}
-
-		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
 
 		if (tocpy == db->db_size)
 			dmu_buf_fill_done(db, tx);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3695,6 +3695,12 @@ metaslab_flush_update(metaslab_t *msp, dmu_tx_t *tx)
 	metaslab_group_t *mg = msp->ms_group;
 	spa_t *spa = mg->mg_vd->vdev_spa;
 
+	if (spa_exiting_any(spa)) {
+		cmn_err(CE_WARN, "metaslab_flush_update(): spa_exiting_any(%s) = true"
+		    ", aborting metaslab_flush_update()", spa_name(spa));
+		return;
+	}
+
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
 	ASSERT3U(spa_sync_pass(spa), ==, 1);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3757,6 +3757,8 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 		    "returning false", spa_name(spa));
 		return (B_FALSE);
 	}
+	zfs_dbgmsg("metaslab_flush(): spa_exiting_any(%s) = false",
+	    spa_name(spa));
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT3U(spa_sync_pass(spa), ==, 1);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3753,11 +3753,11 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
 
 	if (spa_exiting_any(spa)) {
-		zfs_dbgmsg("metaslab_flush(): spa_exiting_any(%s), "
-		    "returning false", spa_name(spa));
+		cmn_err(CE_WARN, "metaslab_flush(): spa_exiting_any(%s) = true"
+		    ", aborting metaslab_flush()", spa_name(spa));
 		return (B_FALSE);
 	}
-	zfs_dbgmsg("metaslab_flush(): spa_exiting_any(%s) = false",
+	cmn_err(CE_WARN, "metaslab_flush(): spa_exiting_any(%s) = false",
 	    spa_name(spa));
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3752,6 +3752,9 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 {
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
 
+	if (spa_exiting(spa))
+		return (B_FALSE);
+
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT3U(spa_sync_pass(spa), ==, 1);
 	ASSERT(spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP));

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -6188,6 +6188,9 @@ metaslab_update_ondisk_flush_data(metaslab_t *ms, dmu_tx_t *tx)
 		VERIFY0(zap_add(mos, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1,
 		    &object, tx));
+	} else if (err != 0 && spa_exiting_any(spa)) {
+		cmn_err(CE_WARN, "metaslab_update_ondisk_flush_data(): aborting due to forced export");
+		return;
 	} else {
 		VERIFY0(err);
 	}

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3752,8 +3752,11 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 {
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
 
-	if (spa_exiting(spa))
+	if (spa_exiting_any(spa)) {
+		zfs_dbgmsg("metaslab_flush(): spa_exiting_any(%s), "
+		    "returning false", spa_name(spa));
 		return (B_FALSE);
+	}
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT3U(spa_sync_pass(spa), ==, 1);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6016,6 +6016,8 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	if (!force_removal && spa->spa_sync_on) {
 		error = txg_wait_synced_tx(spa->spa_dsl_pool, 0,
 		    NULL, TXG_WAIT_F_NOSUSPEND);
+		cmn_err(CE_WARN, "txg_wait_synced_tx(%s) = %d",
+		    spa_name(spa), error);
 		if (error != 0)
 			goto fail;
 		spa_evicting_os_wait(spa);
@@ -6048,6 +6050,8 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	if (!spa_refcount_zero(spa) || (spa->spa_inject_ref != 0)) {
 		VERIFY(!force_removal);
 		error = SET_ERROR(EBUSY);
+		cmn_err(CE_WARN, ""spa_export_common(%s) = %d, refcount not zero",
+		    spa_name(spa), error);
 		goto fail;
 	}
 
@@ -6111,7 +6115,9 @@ export_spa:
 		cmn_err(CE_WARN, "spa_export_common(%s) spa_unload(, %d)",
 		    spa_name(spa), txg_how);
 		error = spa_unload(spa, txg_how);
-		if (error != 0)
+		cmn_err(CE_WARN, "spa_export_common(%s) spa_unload = %d",
+		    spa_name(spa), error);
+		if (!spa_exiting_any(spa) && error != 0)
 			goto fail;
 		spa_deactivate(spa);
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5912,13 +5912,13 @@ static void
 spa_set_killer(spa_t *spa, void *killer)
 {
 
-	zfs_dbgmsg("spa_set_killer(%s):enter = %p", spa_name(spa), killer);
+	cmn_err(CE_WARN, "spa_set_killer(%s):enter = %p", spa_name(spa), killer);
 	mutex_enter(&spa->spa_evicting_os_lock);
 	spa->spa_killer = killer;
 	if (killer != NULL)
 		txg_completion_notify(spa_get_dsl(spa));
 	mutex_exit(&spa->spa_evicting_os_lock);
-	zfs_dbgmsg("spa_set_killer(%s):exit = %p", spa_name(spa), killer);
+	cmn_err(CE_WARN, "spa_set_killer(%s):exit = %p", spa_name(spa), killer);
 }
 
 /*
@@ -5974,7 +5974,7 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	force_removal = hardforce && modifying;
 	if (force_removal) {
 		/* Ensure that references see this change after this. */
-		zfs_dbgmsg("spa_export_common(%s) starting forced export", spa_name(spa));
+		cmn_err(CE_WARN, "spa_export_common(%s) starting forced export", spa_name(spa));
 		spa_set_killer(spa, curthread);
 	}
 	mutex_exit(&spa_namespace_lock);
@@ -5988,7 +5988,7 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	if (force_removal && spa->spa_sync_on) {
 		error = dsl_dataset_sendrecv_cancel_all(spa);
 		if (error != 0) {
-			zfs_dbgmsg("spa_export_common(%s) cancelling forced "
+			cmn_err(CE_WARN, "spa_export_common(%s) cancelling forced "
 			    "export due to send/recv error", spa_name(spa));
 			spa_set_killer(spa, NULL);
 			spa_async_resume(spa);
@@ -6108,7 +6108,7 @@ export_spa:
 		 * suspension and abort.
 		 */
 		txg_how = (!hardforce) ? TXG_WAIT_F_NOSUSPEND : 0;
-		zfs_dbgmsg("spa_export_common(%s) spa_unload(, %d)",
+		cmn_err(CE_WARN, "spa_export_common(%s) spa_unload(, %d)",
 		    spa_name(spa), txg_how);
 		error = spa_unload(spa, txg_how);
 		if (error != 0)
@@ -6130,7 +6130,7 @@ export_spa:
 
 fail:
 	if (force_removal) {
-		zfs_dbgmsg("spa_export_common(%s) cancelling forced export "
+		cmn_err(CE_WARN, "spa_export_common(%s) cancelling forced export "
 		    "due to error=%d", spa_name(spa), error);
 		spa_set_killer(spa, NULL);
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6050,7 +6050,7 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	if (!spa_refcount_zero(spa) || (spa->spa_inject_ref != 0)) {
 		VERIFY(!force_removal);
 		error = SET_ERROR(EBUSY);
-		cmn_err(CE_WARN, ""spa_export_common(%s) = %d, refcount not zero",
+		cmn_err(CE_WARN, "spa_export_common(%s) = %d, refcount not zero",
 		    spa_name(spa), error);
 		goto fail;
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5912,11 +5912,13 @@ static void
 spa_set_killer(spa_t *spa, void *killer)
 {
 
+	zfs_dbgmsg("spa_set_killer(%s):enter = %p", spa_name(spa), killer);
 	mutex_enter(&spa->spa_evicting_os_lock);
 	spa->spa_killer = killer;
 	if (killer != NULL)
 		txg_completion_notify(spa_get_dsl(spa));
 	mutex_exit(&spa->spa_evicting_os_lock);
+	zfs_dbgmsg("spa_set_killer(%s):exit = %p", spa_name(spa), killer);
 }
 
 /*
@@ -5972,6 +5974,7 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	force_removal = hardforce && modifying;
 	if (force_removal) {
 		/* Ensure that references see this change after this. */
+		zfs_dbgmsg("spa_export_common(%s) starting forced export", spa_name(spa));
 		spa_set_killer(spa, curthread);
 	}
 	mutex_exit(&spa_namespace_lock);
@@ -5985,6 +5988,8 @@ spa_export_common(char *pool, int new_state, nvlist_t **oldconfig,
 	if (force_removal && spa->spa_sync_on) {
 		error = dsl_dataset_sendrecv_cancel_all(spa);
 		if (error != 0) {
+			zfs_dbgmsg("spa_export_common(%s) cancelling forced "
+			    "export due to send/recv error", spa_name(spa));
 			spa_set_killer(spa, NULL);
 			spa_async_resume(spa);
 			return (error);
@@ -6103,6 +6108,8 @@ export_spa:
 		 * suspension and abort.
 		 */
 		txg_how = (!hardforce) ? TXG_WAIT_F_NOSUSPEND : 0;
+		zfs_dbgmsg("spa_export_common(%s) spa_unload(, %d)",
+		    spa_name(spa), txg_how);
 		error = spa_unload(spa, txg_how);
 		if (error != 0)
 			goto fail;
@@ -6122,8 +6129,11 @@ export_spa:
 	return (0);
 
 fail:
-	if (force_removal)
+	if (force_removal) {
+		zfs_dbgmsg("spa_export_common(%s) cancelling forced export "
+		    "due to error=%d", spa_name(spa), error);
 		spa_set_killer(spa, NULL);
+	}
 	spa_async_resume(spa);
 	mutex_exit(&spa_namespace_lock);
 	return (error);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1495,7 +1495,7 @@ spa_should_flush_logs_on_unload(spa_t *spa)
 	if (!spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP))
 		return (B_FALSE);
 
-	if (spa_exiting(spa))
+	if (spa_exiting_any(spa))
 		return (B_FALSE);
 
 	if (!spa_writeable(spa))

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1495,6 +1495,9 @@ spa_should_flush_logs_on_unload(spa_t *spa)
 	if (!spa_feature_is_active(spa, SPA_FEATURE_LOG_SPACEMAP))
 		return (B_FALSE);
 
+	if (spa_exiting(spa))
+		return (B_FALSE);
+
 	if (!spa_writeable(spa))
 		return (B_FALSE);
 

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -717,7 +717,7 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 {
 	uint64_t txg = dmu_tx_get_txg(tx);
 
-	if (spa_exiting(spa))
+	if (spa_exiting_any(spa))
 		return;
 
 	if (spa_sync_pass(spa) != 1)

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -717,6 +717,9 @@ spa_flush_metaslabs(spa_t *spa, dmu_tx_t *tx)
 {
 	uint64_t txg = dmu_tx_get_txg(tx);
 
+	if (spa_exiting(spa))
+		return;
+
 	if (spa_sync_pass(spa) != 1)
 		return;
 

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -527,6 +527,7 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
     maptype_t maptype, uint64_t vdev_id, uint8_t words, dmu_buf_t **dbp,
     void *tag, dmu_tx_t *tx)
 {
+	spa_t *spa = tx->tx_pool->dp_spa;
 	int error;
 
 	ASSERT3U(words, !=, 0);
@@ -574,7 +575,7 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 			error = dmu_buf_hold(sm->sm_os,
 			    space_map_object(sm), next_word_offset,
 			    tag, &db, DMU_READ_PREFETCH);
-			VERIFY(error == 0 || spa_exiting_any(sm->sm_os->os_spa));
+			VERIFY(error == 0 || spa_exiting_any(spa));
 			if (error != 0)
 				return;
 
@@ -677,7 +678,7 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	uint64_t next_word_offset = sm->sm_phys->smp_length;
 	error = dmu_buf_hold(sm->sm_os, space_map_object(sm),
 	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH);
-	VERIFY(error == 0 || spa_exiting_any(sm->sm_os->os_spa));
+	VERIFY(error == 0 || spa_exiting_any(spa));
 	if (error != 0)
 		return;
 

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -527,6 +527,8 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
     maptype_t maptype, uint64_t vdev_id, uint8_t words, dmu_buf_t **dbp,
     void *tag, dmu_tx_t *tx)
 {
+	int error;
+
 	ASSERT3U(words, !=, 0);
 	ASSERT3U(words, <=, 2);
 
@@ -569,9 +571,13 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 			dmu_buf_rele(db, tag);
 
 			uint64_t next_word_offset = sm->sm_phys->smp_length;
-			VERIFY0(dmu_buf_hold(sm->sm_os,
+			error = dmu_buf_hold(sm->sm_os,
 			    space_map_object(sm), next_word_offset,
-			    tag, &db, DMU_READ_PREFETCH));
+			    tag, &db, DMU_READ_PREFETCH);
+			VERIFY(error == 0 || spa_exiting_any(sm->sm_os->os_spa));
+			if (error != 0)
+				return;
+
 			dmu_buf_will_dirty(db, tx);
 
 			/* update caller's dbuf */
@@ -648,6 +654,7 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 {
 	spa_t *spa = tx->tx_pool->dp_spa;
 	dmu_buf_t *db;
+	int error;
 
 	space_map_write_intro_debug(sm, maptype, tx);
 
@@ -668,8 +675,12 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	 * start appending to it.
 	 */
 	uint64_t next_word_offset = sm->sm_phys->smp_length;
-	VERIFY0(dmu_buf_hold(sm->sm_os, space_map_object(sm),
-	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH));
+	error = dmu_buf_hold(sm->sm_os, space_map_object(sm),
+	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH);
+	VERIFY(error == 0 || spa_exiting_any(sm->sm_os->os_spa));
+	if (error != 0)
+		return;
+
 	ASSERT3U(db->db_size, ==, sm->sm_blksz);
 
 	dmu_buf_will_dirty(db, tx);

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -576,8 +576,10 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 			    space_map_object(sm), next_word_offset,
 			    tag, &db, DMU_READ_PREFETCH);
 			VERIFY(error == 0 || spa_exiting_any(spa));
-			if (error != 0)
+			if (error != 0) {
+				cmn_err(CE_WARN, "space_map_write_seg() error=%d", error);
 				return;
+			}
 
 			dmu_buf_will_dirty(db, tx);
 
@@ -679,8 +681,10 @@ space_map_write_impl(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
 	error = dmu_buf_hold(sm->sm_os, space_map_object(sm),
 	    next_word_offset, FTAG, &db, DMU_READ_PREFETCH);
 	VERIFY(error == 0 || spa_exiting_any(spa));
-	if (error != 0)
+	if (error != 0) {
+		cmn_err(CE_WARN, "space_map_write_impl() error=%d", error);
 		return;
+	}
 
 	ASSERT3U(db->db_size, ==, sm->sm_blksz);
 

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -732,6 +732,11 @@ void
 space_map_write(space_map_t *sm, range_tree_t *rt, maptype_t maptype,
     uint64_t vdev_id, dmu_tx_t *tx)
 {
+	spa_t *spa = tx->tx_pool->dp_spa;
+
+	if (spa_exiting_any(spa))
+		return;
+
 	ASSERT(dsl_pool_sync_context(dmu_objset_pool(sm->sm_os)));
 	VERIFY3U(space_map_object(sm), !=, 0);
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -279,8 +279,10 @@ txg_sync_stop(dsl_pool_t *dp, uint64_t txg_how)
 	 */
 	err = txg_wait_synced_tx(dp, tx->tx_open_txg + TXG_DEFER_SIZE,
 	    NULL, txg_how);
-	if (err != 0)
+	if (err != 0) {
+		cmn_err(CE_WARN, "txg_sync_stop() txg_wait_synced_tx=%d", err);
 		return (err);
+	}
 
 	/*
 	 * Wake all sync threads and wait for them to die.


### PR DESCRIPTION
To start we try to restrict this to the specific SPA to avoid impacting other pools

Signed-off-by: Allan Jude <allanjude@freebsd.org>
