### PR TITLE
forced export fixes

### DIFF
--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -78,6 +78,8 @@ typedef enum {
 	TXG_WAIT_F_SIGNAL	= (1U << 0),
 	/* Reject the call with EAGAIN upon suspension. */
 	TXG_WAIT_F_NOSUSPEND	= (1U << 1),
+	/* Ignore errors and export anyway. */
+	TXG_WAIT_F_FORCE_EXPORT	= (1U << 2),
 } txg_wait_flag_t;
 
 extern void txg_init(struct dsl_pool *dp, uint64_t txg);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -6152,6 +6152,10 @@ metaslab_enable(metaslab_t *msp, boolean_t sync, boolean_t unload)
 	metaslab_group_t *mg = msp->ms_group;
 	spa_t *spa = mg->mg_vd->vdev_spa;
 
+	if (spa_exiting_any(spa)) {
+		return;
+	}
+
 	/*
 	 * Wait for the outstanding IO to be synced to prevent newly
 	 * allocated blocks from being overwritten.  This used by

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -6194,6 +6194,8 @@ metaslab_update_ondisk_flush_data(metaslab_t *ms, dmu_tx_t *tx)
 		VERIFY0(zap_add(mos, vd->vdev_top_zap,
 		    VDEV_TOP_ZAP_MS_UNFLUSHED_PHYS_TXGS, sizeof (uint64_t), 1,
 		    &object, tx));
+	} else if (spa_exiting_any(spa)) {
+		/* Do nothing */
 	} else {
 		VERIFY0(err);
 	}

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3770,6 +3770,9 @@ metaslab_flush(metaslab_t *msp, dmu_tx_t *tx)
 	ASSERT(metaslab_unflushed_txg(msp) != 0);
 	ASSERT(avl_find(&spa->spa_metaslabs_by_flushed, msp, NULL) != NULL);
 
+	if (spa_exiting_any(spa)) {
+		return (B_FALSE);
+	}
 	/*
 	 * There is nothing wrong with flushing the same metaslab twice, as
 	 * this codepath should work on that case. However, the current

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1407,6 +1407,8 @@ spa_deactivate(spa_t *spa)
 	if (spa_exiting_any(spa)) {
 		metaslab_class_force_discard(spa->spa_normal_class);
 		metaslab_class_force_discard(spa->spa_log_class);
+		metaslab_class_force_discard(spa->spa_special_class);
+		metaslab_class_force_discard(spa->spa_dedup_class);
 	}
 
 	metaslab_class_destroy(spa->spa_normal_class);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6561,8 +6561,8 @@ export_spa:
 		 * If the pool is not being hard forced, throw an error upon
 		 * suspension and abort.
 		 */
-		error = spa_unload(spa,
-		    hardforce ? TXG_WAIT_F_NONE : TXG_WAIT_F_NOSUSPEND);
+		error = spa_unload(spa, hardforce ?
+		    TXG_WAIT_F_FORCE_EXPORT : TXG_WAIT_F_NOSUSPEND);
 		if (error != 0)
 			goto fail;
 		spa_deactivate(spa);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -364,8 +364,9 @@ spa_all_configs(uint64_t *generation)
 
 	mutex_enter(&spa_namespace_lock);
 	while ((spa = spa_next(spa)) != NULL) {
-		if (INGLOBALZONE(curproc) ||
-		    zone_dataset_visible(spa_name(spa), NULL)) {
+		if (!spa_exiting_any(spa) &&
+		    (INGLOBALZONE(curproc) ||
+		    zone_dataset_visible(spa_name(spa), NULL))) {
 			mutex_enter(&spa->spa_props_lock);
 			fnvlist_add_nvlist(pools, spa_name(spa),
 			    spa->spa_config);
@@ -403,6 +404,13 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	boolean_t locked = B_FALSE;
 	uint64_t split_guid;
 	char *pool_name;
+
+	if (spa_exiting_any(spa)) {
+		config = fnvlist_alloc();
+		fnvlist_add_string(config, ZPOOL_CONFIG_POOL_NAME, pool_name);
+		fnvlist_add_uint64(config, ZPOOL_CONFIG_POOL_STATE, POOL_STATE_UNINITIALIZED);
+		return (config);
+	}
 
 	if (vd == NULL) {
 		vd = rvd;

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -924,6 +924,9 @@ spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 	uint64_t txg = dmu_tx_get_txg(tx);
 	objset_t *mos = spa_meta_objset(spa);
 
+	if (spa_exiting_any(spa))
+		return;
+
 	if (spa_syncing_log_sm(spa) != NULL)
 		return;
 
@@ -944,6 +947,8 @@ spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 		    &spacemap_zap, tx));
 		spa_feature_incr(spa, SPA_FEATURE_LOG_SPACEMAP, tx);
 	}
+	if (error && spa_exiting_any(spa))
+		return;
 	VERIFY0(error);
 
 	uint64_t sm_obj;

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -724,13 +724,22 @@ txg_wait_synced_tx(dsl_pool_t *dp, uint64_t txg, dmu_tx_t *tx,
 		 * data isn't going to be pushed.
 		 */
 		if (spa_suspended(dp->dp_spa)) {
+			if ((flags & TXG_WAIT_F_FORCE_EXPORT)) {
+				error = 0;
+				break;
+			}
 			if ((flags & TXG_WAIT_F_NOSUSPEND) ||
 			    spa_exiting_any(dp->dp_spa)) {
 				error = SET_ERROR(EAGAIN);
 			}
 		}
-		if (error == 0 && os != NULL && dmu_objset_exiting(os))
+		if (error == 0 && os != NULL && dmu_objset_exiting(os)) {
+			if ((flags & TXG_WAIT_F_FORCE_EXPORT)) {
+				error = 0;
+				break;
+			}
 			error = SET_ERROR(EAGAIN);
+		}
 		if (error != 0)
 			break;
 		if (flags & TXG_WAIT_F_SIGNAL) {

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -570,7 +570,7 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		}
 	}
 
-	if (getstats) {
+	if (getstats && !spa_exiting_any(spa)) {
 		vdev_config_generate_stats(vd, nv);
 
 		root_vdev_actions_getprogress(vd, nv);

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -167,7 +167,8 @@ static boolean_t
 vdev_trim_should_stop(vdev_t *vd)
 {
 	return (vd->vdev_trim_exit_wanted || !vdev_writeable(vd) ||
-	    vd->vdev_detached || vd->vdev_top->vdev_removing);
+	    vd->vdev_detached || vd->vdev_top->vdev_removing ||
+	    spa_exiting_any(vd->vdev_spa));
 }
 
 /*
@@ -178,7 +179,8 @@ vdev_autotrim_should_stop(vdev_t *tvd)
 {
 	return (tvd->vdev_autotrim_exit_wanted ||
 	    !vdev_writeable(tvd) || tvd->vdev_removing ||
-	    spa_get_autotrim(tvd->vdev_spa) == SPA_AUTOTRIM_OFF);
+	    spa_get_autotrim(tvd->vdev_spa) == SPA_AUTOTRIM_OFF ||
+	    spa_exiting_any(tvd->vdev_spa));
 }
 
 /*

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1352,6 +1352,9 @@ put_nvlist(zfs_cmd_t *zc, nvlist_t *nvl)
 	int error = 0;
 	size_t size;
 
+	if (nvl == NULL)
+		return (SET_ERROR(EINVAL));
+
 	size = fnvlist_size(nvl);
 
 	if (size > zc->zc_nvlist_dst_size) {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1355,12 +1355,15 @@ put_nvlist(zfs_cmd_t *zc, nvlist_t *nvl)
 	if (nvl == NULL)
 		return (SET_ERROR(EINVAL));
 
-	size = fnvlist_size(nvl);
+	if (nvlist_size(nvl, &size, NV_ENCODE_NATIVE))
+		return (SET_ERROR(EINVAL));
 
 	if (size > zc->zc_nvlist_dst_size) {
 		error = SET_ERROR(ENOMEM);
 	} else {
-		packed = fnvlist_pack(nvl, &size);
+		if (nvlist_pack(nvl, &packed, &size, NV_ENCODE_NATIVE,
+		    KM_SLEEP))
+			return (SET_ERROR(EINVAL));
 		if (ddi_copyout(packed, (void *)(uintptr_t)zc->zc_nvlist_dst,
 		    size, zc->zc_iflags) != 0)
 			error = SET_ERROR(EFAULT);


### PR DESCRIPTION
This pull request against spp-10.1.8-2.0.2 branch, solves an issue where the system would PANIC when doing a `zpool list` at the wrong moment during an export.

It also ensures that a forced export will not abort due to EAGAIN, and I've also added code to avoid the panic in the spacemap code.
