### PR TITLE
Fix miss merge of sending encrypted datasets

### DIFF
--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -56,10 +56,10 @@ typedef struct dmu_recv_cookie {
 	nvlist_t *drc_keynvl;
 	zio_cksum_t drc_cksum;
 	uint64_t drc_fromsnapobj;
+	uint64_t drc_ivset_guid;
 	uint64_t drc_newsnapobj;
 	unsigned int drc_flags;
 	void *drc_rwa;
-	uint64_t drc_ivset_guid;
 	void *drc_owner;
 	cred_t *drc_cred;
 } dmu_recv_cookie_t;

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -3897,6 +3897,31 @@ top of an existing snapshot, ZFS will check to confirm that the "from"
 snapshot on both the source and destination were using the same IV set,
 ensuring the new IV set is consistent.
 .Pp
+The added security provided by raw sends adds some restrictions to the send
+and receive process. ZFS will not allow a mix of raw receives and non-raw
+receives. Specifically, any raw incremental receives that are attempted after
+a non-raw receive will fail. Non-raw receives do not have this restriction and,
+therefore, are always possible. Because of this, it is best practice to always
+use either raw sends for their security benefits or non-raw sends for their
+flexibility when working with encrypted datasets, but not a combination.
+.Pp
+The reason for this restriction stems from the inherent restrictions of the
+AEAD ciphers that ZFS uses to encrypt data. When using ZFS native encryption,
+each block of data is encrypted against a randomly generated number known as
+the "initialization vector" (IV), which is stored in the filesystem metadata.
+This number is required by the encryption algorithms whenever the data is to
+be decrypted. Together, all of the IVs provided for all of the blocks in a
+given snapshot are collectively called an "IV set". When ZFS performs a raw
+send, the IV set is transferred from the source to the destination in the send
+stream. When ZFS performs a non-raw send, the data is decrypted by the source
+system and re-encrypted by the destination system, creating a snapshot with
+effectively the same data, but a different IV set. In order for decryption to
+work after a raw send, ZFS must ensure that the IV set used on both the source
+and destination side match. When an incremental raw receive is performed on
+top of an existing snapshot, ZFS will check to confirm that the "from"
+snapshot on both the source and destination were using the same IV set,
+ensuring the new IV set is consistent.
+.Pp
 The name of the snapshot
 .Pq and file system, if a full stream is received
 that this subcommand creates depends on the argument type and the use of the

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -2823,7 +2823,7 @@ dmu_recv_stream(dmu_recv_cookie_t *drc, vnode_t *vp, offset_t *voffp,
 		if (err != 0)
 			kmem_free(ra->rrd, sizeof (*ra->rrd));
 		ra->rrd = NULL;
-	}
+	}	
 
 	if (err == 0 && rwa->err == 0) {
 		ASSERT3P(ra->rrd, ==, NULL);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1272,6 +1272,12 @@ dmu_send(dsl_pool_t **dpp, dsl_dataset_t *to_ds, dsl_dataset_t *fromds,
 		zb.zbm_creation_txg = dsl_dataset_phys(fromds)->ds_creation_txg;
 		zb.zbm_guid = dsl_dataset_phys(fromds)->ds_guid;
 		is_clone = (fromds->ds_dir != to_ds->ds_dir);
+		if (dsl_dataset_is_zapified(fromds)) {
+			(void) zap_lookup(dp->dp_meta_objset,
+				fromds->ds_object,
+				DS_FIELD_IVSET_GUID, 8, 1,
+				&zb.zbm_ivset_guid);
+		}
 	} else if (fromzb != NULL) {
 		ASSERT3P(fromds, ==, NULL);
 		err = dsl_bookmark_lookup(dp, fromzb, to_ds, &zb);


### PR DESCRIPTION
The missing part was to retrieve ivset guid from the snapshot

Signed-off-by: Mariusz Zaborski oshogbo@FreeBSD.org